### PR TITLE
* Maintain one Argo revision hash throughout a pipeline run

### DIFF
--- a/clientwrapper/atlasoperator/atlas_operator.go
+++ b/clientwrapper/atlasoperator/atlas_operator.go
@@ -32,6 +32,7 @@ var channel chan string
 func deploy(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	deployType := vars["type"]
+	revision := vars["revision"]
 	byteReqBody, _ := ioutil.ReadAll(r.Body)
 	stringReqBody := string(byteReqBody)
 	var success bool
@@ -39,7 +40,7 @@ func deploy(w http.ResponseWriter, r *http.Request) {
 	var appNamespace string
 	var revisionHash string
 	if deployType == requestdatatypes.DeployArgoRequest {
-		success, resourceName, appNamespace, revisionHash = drivers.argoDriver.Deploy(&stringReqBody)
+		success, resourceName, appNamespace, revisionHash = drivers.argoDriver.Deploy(&stringReqBody, revision)
 	} else if deployType == requestdatatypes.DeployTestRequest {
 		var kubernetesCreationRequest requestdatatypes.KubernetesCreationRequest
 		err := json.NewDecoder(strings.NewReader(stringReqBody)).Decode(&kubernetesCreationRequest)
@@ -210,7 +211,7 @@ func watch(w http.ResponseWriter, r *http.Request) {
 
 func handleRequests() {
 	myRouter := mux.NewRouter().StrictSlash(true)
-	myRouter.HandleFunc("/deploy/{orgName}/{type}", deploy).Methods("POST")
+	myRouter.HandleFunc("/deploy/{orgName}/{type}/{revision}", deploy).Methods("POST")
 	myRouter.HandleFunc("/deploy/{orgName}/{type}/{argoAppName}", deployArgoAppByName).Methods("POST")
 	myRouter.HandleFunc("/delete/{orgName}/{type}/{resourceName}/{resourceNamespace}/{group}/{version}{kind}", deleteResource).Methods("POST")
 	myRouter.HandleFunc("/delete/{orgName}/{type}", deleteResourceFromConfig).Methods("POST")

--- a/util/src/main/java/com/greenops/util/datamodel/auditlog/DeploymentLog.java
+++ b/util/src/main/java/com/greenops/util/datamodel/auditlog/DeploymentLog.java
@@ -10,7 +10,8 @@ public class DeploymentLog {
         FAILURE
     }
 
-    private final String uniqueVersionNumber;
+    private final String pipelineUniqueVersionNumber;
+    private final String rollbackUniqueVersionNumber;
     private final int uniqueVersionInstance;
     private String status;
     private boolean deploymentComplete;
@@ -20,8 +21,9 @@ public class DeploymentLog {
     private String brokenTest;
     private String brokenTestLog;
 
-    public DeploymentLog(String uniqueVersionNumber, int uniqueVersionInstance, String status, boolean deploymentComplete, String argoApplicationName, String argoRevisionHash, String gitCommitVersion, String brokenTest, String brokenTestLog) {
-        this.uniqueVersionNumber = uniqueVersionNumber;
+    public DeploymentLog(String pipelineUniqueVersionNumber, String rollbackUniqueVersionNumber, int uniqueVersionInstance, String status, boolean deploymentComplete, String argoApplicationName, String argoRevisionHash, String gitCommitVersion, String brokenTest, String brokenTestLog) {
+        this.pipelineUniqueVersionNumber = pipelineUniqueVersionNumber == null ? UUID.randomUUID().toString() : pipelineUniqueVersionNumber;
+        this.rollbackUniqueVersionNumber = rollbackUniqueVersionNumber;
         this.uniqueVersionInstance = uniqueVersionInstance;
         this.status = status;
         this.argoApplicationName = argoApplicationName;
@@ -32,12 +34,16 @@ public class DeploymentLog {
         this.brokenTestLog = brokenTestLog;
     }
 
-    public DeploymentLog(String status, boolean deploymentComplete, String argoRevisionHash, String gitCommitVersion) {
-        this(UUID.randomUUID().toString(), 0, status, deploymentComplete, null, argoRevisionHash, gitCommitVersion, null, null);
+    public DeploymentLog(String pipelineUniqueVersionNumber, String status, boolean deploymentComplete, String argoRevisionHash, String gitCommitVersion) {
+        this(pipelineUniqueVersionNumber, null, 0, status, deploymentComplete, null, argoRevisionHash, gitCommitVersion, null, null);
     }
 
-    public String getUniqueVersionNumber() {
-        return uniqueVersionNumber;
+    public String getPipelineUniqueVersionNumber() {
+        return pipelineUniqueVersionNumber;
+    }
+
+    public String getRollbackUniqueVersionNumber() {
+        return rollbackUniqueVersionNumber;
     }
 
     public int getUniqueVersionInstance() {

--- a/util/src/main/java/com/greenops/util/datamodel/event/TriggerStepEvent.java
+++ b/util/src/main/java/com/greenops/util/datamodel/event/TriggerStepEvent.java
@@ -6,13 +6,17 @@ public class TriggerStepEvent implements Event {
     private String teamName;
     private String pipelineName;
     private String stepName;
+    private String argoRevisionHash;
+    private String pipelineUvn;
     private boolean rollback;
 
-    public TriggerStepEvent(String orgName, String teamName, String pipelineName, String stepName, boolean rollback) {
+    public TriggerStepEvent(String orgName, String teamName, String pipelineName, String stepName, String argoRevisionHash, String pipelineUvn, boolean rollback) {
         this.orgName = orgName;
         this.teamName = teamName;
         this.pipelineName = pipelineName;
         this.stepName = stepName;
+        this.argoRevisionHash = argoRevisionHash;
+        this.pipelineUvn = pipelineUvn;
         this.rollback = rollback;
     }
 
@@ -34,6 +38,14 @@ public class TriggerStepEvent implements Event {
     @Override
     public String getStepName() {
         return stepName;
+    }
+
+    public String getArgoRevisionHash() {
+        return argoRevisionHash;
+    }
+
+    public String getPipelineUvn() {
+        return pipelineUvn;
     }
 
     public boolean isRollback() {

--- a/util/src/main/java/com/greenops/util/datamodel/mixin/auditlog/DeploymentLogMixin.java
+++ b/util/src/main/java/com/greenops/util/datamodel/mixin/auditlog/DeploymentLogMixin.java
@@ -5,8 +5,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class DeploymentLogMixin {
 
-    @JsonProperty(value = "uniqueVersionNumber")
-    private String uniqueVersionNumber;
+    @JsonProperty(value = "pipelineUniqueVersionNumber")
+    private String pipelineUniqueVersionNumber;
+
+    @JsonProperty(value = "rollbackUniqueVersionNumber")
+    private String rollbackUniqueVersionNumber;
 
     @JsonProperty(value = "uniqueVersionInstance")
     private int uniqueVersionInstance;
@@ -33,7 +36,8 @@ public class DeploymentLogMixin {
     private String brokenTestLog;
 
     @JsonCreator
-    DeploymentLogMixin(@JsonProperty(value = "uniqueVersionNumber") String uniqueVersionNumber,
+    DeploymentLogMixin(@JsonProperty(value = "pipelineUniqueVersionNumber") String pipelineUniqueVersionNumber,
+                       @JsonProperty(value = "rollbackUniqueVersionNumber") String rollbackUniqueVersionNumber,
                        @JsonProperty(value = "uniqueVersionInstance") int uniqueVersionInstance,
                        @JsonProperty(value = "status") String status,
                        @JsonProperty(value = "deploymentComplete") boolean deploymentComplete,

--- a/util/src/main/java/com/greenops/util/datamodel/mixin/event/TriggerStepEventMixin.java
+++ b/util/src/main/java/com/greenops/util/datamodel/mixin/event/TriggerStepEventMixin.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public abstract class TriggerStepEventMixin{
+public abstract class TriggerStepEventMixin {
 
     @JsonProperty(value = "orgName")
     String orgName;
@@ -14,6 +14,10 @@ public abstract class TriggerStepEventMixin{
     String pipelineName;
     @JsonProperty(value = "stepName")
     String stepName;
+    @JsonProperty(value = "argoRevisionHash")
+    String argoRevisionHash;
+    @JsonProperty(value = "pipelineUvn")
+    String pipelineUvn;
     @JsonProperty(value = "rollback")
     boolean rollback;
 
@@ -22,6 +26,8 @@ public abstract class TriggerStepEventMixin{
                                  @JsonProperty(value = "teamName") String teamName,
                                  @JsonProperty(value = "pipelineName") String pipelineName,
                                  @JsonProperty(value = "stepName") String stepName,
+                                 @JsonProperty(value = "argoRevisionHash") String argoRevisionHash,
+                                 @JsonProperty(value = "pipelineUvn") String pipelineUvn,
                                  @JsonProperty(value = "rollback") boolean rollback) {
     }
 

--- a/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/apiclient/clientwrapper/ClientWrapperApi.java
+++ b/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/apiclient/clientwrapper/ClientWrapperApi.java
@@ -5,6 +5,8 @@ import com.greenops.workfloworchestrator.datamodel.requests.WatchRequest;
 
 public interface ClientWrapperApi {
 
+    static final String LATEST_REVISION = "LATEST_REVISION";
+
     static final String DEPLOY_ARGO_REQUEST = "DeployArgoRequest";
     static final String DEPLOY_KUBERNETES_REQUEST = "DeployKubernetesRequest";
     static final String DEPLOY_TEST_REQUEST = "DeployTestRequest";
@@ -12,7 +14,7 @@ public interface ClientWrapperApi {
     static final String DELETE_KUBERNETES_REQUEST = "DeleteKubernetesRequest";
     static final String DELETE_TEST_REQUEST = "DeleteTestRequest";
 
-    public DeployResponse deploy(String clusterName, String orgName, String type, Object payload);
+    public DeployResponse deploy(String clusterName, String orgName, String type, String revisionHash, Object payload);
 
     public DeployResponse deployArgoAppByName(String clusterName, String orgName, String appName);
 

--- a/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/apiclient/clientwrapper/ClientWrapperApiImpl.java
+++ b/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/apiclient/clientwrapper/ClientWrapperApiImpl.java
@@ -37,8 +37,8 @@ public class ClientWrapperApiImpl implements ClientWrapperApi {
     }
 
     @Override
-    public DeployResponse deploy(String clusterName, String orgName, String type, Object payload) {
-        var request = new HttpPost(serverEndpoint + String.format("/deploy/%s/%s", orgName, type));
+    public DeployResponse deploy(String clusterName, String orgName, String type, String revisionHash, Object payload) {
+        var request = new HttpPost(serverEndpoint + String.format("/deploy/%s/%s/%s", orgName, type, revisionHash));
         try {
             var body = type.equals(DEPLOY_TEST_REQUEST) ? objectMapper.writeValueAsString(payload) : (String)payload;
             request.setEntity(new StringEntity(body, ContentType.DEFAULT_TEXT));

--- a/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/handling/DeploymentHandler.java
+++ b/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/handling/DeploymentHandler.java
@@ -8,6 +8,6 @@ public interface DeploymentHandler {
 
     void deleteApplicationInfrastructure(Event event, String pipelineRepoUrl, StepData stepData, String gitCommitHash);
     void deployApplicationInfrastructure(Event event, String pipelineRepoUrl, StepData stepData, String gitCommitHash);
-    ArgoDeploymentInfo deployArgoApplication(Event event, String pipelineRepoUrl, StepData stepData, String gitCommitHash);
+    ArgoDeploymentInfo deployArgoApplication(Event event, String pipelineRepoUrl, StepData stepData, String argoRevisionHash, String gitCommitHash);
     void rollbackArgoApplication(Event event, String pipelineRepoUrl, StepData stepData, String argoApplicationName, String argoRevisionHash);
 }

--- a/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/handling/DeploymentHandlerImpl.java
+++ b/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/handling/DeploymentHandlerImpl.java
@@ -49,7 +49,7 @@ public class DeploymentHandlerImpl implements DeploymentHandler {
             log.info("Deploying new application infrastructure...");
             for (var deploymentConfig : otherDeploymentsConfig.split("---")) {
                 if (deploymentConfig.isBlank()) continue;
-                var deployResponse = clientWrapperApi.deploy(stepData.getClusterName(), event.getOrgName(), ClientWrapperApi.DEPLOY_KUBERNETES_REQUEST, deploymentConfig);
+                var deployResponse = clientWrapperApi.deploy(stepData.getClusterName(), event.getOrgName(), ClientWrapperApi.DEPLOY_KUBERNETES_REQUEST, ClientWrapperApi.LATEST_REVISION, deploymentConfig);
                 if (!deployResponse.getSuccess()) {
                     var message = "Deploying other resources failed.";
                     log.error(message);
@@ -60,13 +60,13 @@ public class DeploymentHandlerImpl implements DeploymentHandler {
     }
 
     @Override
-    public ArgoDeploymentInfo deployArgoApplication(Event event, String pipelineRepoUrl, StepData stepData, String gitCommitHash) {
+    public ArgoDeploymentInfo deployArgoApplication(Event event, String pipelineRepoUrl, StepData stepData, String argoRevisionHash, String gitCommitHash) {
         if (stepData.getArgoApplicationPath() != null) {
             var getFileRequest = new GetFileRequest(pipelineRepoUrl, stepData.getArgoApplicationPath(), gitCommitHash);
             var argoApplicationConfig = repoManagerApi.getFileFromRepo(getFileRequest, event.getOrgName(), event.getTeamName());
             //TODO: The splitting of the config file should eventually be done on the client side
             for (var applicationConfig : argoApplicationConfig.split("---")) {
-                var deployResponse = clientWrapperApi.deploy(stepData.getClusterName(), event.getOrgName(), ClientWrapperApi.DEPLOY_ARGO_REQUEST, applicationConfig);
+                var deployResponse = clientWrapperApi.deploy(stepData.getClusterName(), event.getOrgName(), ClientWrapperApi.DEPLOY_ARGO_REQUEST, ClientWrapperApi.LATEST_REVISION, applicationConfig);
                 log.info("Deploying Argo application {}...", deployResponse.getResourceName());
                 if (!deployResponse.getSuccess()) {
                     var message = "Deploying the Argo application failed.";

--- a/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/handling/DeploymentLogHandler.java
+++ b/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/handling/DeploymentLogHandler.java
@@ -8,7 +8,7 @@ public interface DeploymentLogHandler {
 
     void updateStepDeploymentLog(Event event, String stepName, String argoApplicationName, String revisionHash);
 
-    void initializeNewStepLog(Event event, String stepName, String gitCommitVersion);
+    void initializeNewStepLog(Event event, String stepName, String pipelineUvn, String argoRevisionHash, String gitCommitVersion);
 
     void markDeploymentSuccessful(Event event, String stepName);
 
@@ -23,6 +23,10 @@ public interface DeploymentLogHandler {
     String makeRollbackDeploymentLog(Event event, String stepName);
 
     String getCurrentGitCommitHash(Event event, String stepName);
+
+    String getCurrentArgoRevisionHash(Event event, String stepName);
+
+    String getCurrentPipelineUvn(Event event, String stepName);
 
     String getLastSuccessfulStepGitCommitHash(Event event, String stepName);
 

--- a/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/handling/TestHandlerImpl.java
+++ b/workfloworchestrator/src/main/java/com/greenops/workfloworchestrator/ingest/handling/TestHandlerImpl.java
@@ -46,6 +46,7 @@ public class TestHandlerImpl implements TestHandler {
                 clusterName,
                 event.getOrgName(),
                 ClientWrapperApi.DEPLOY_TEST_REQUEST,
+                ClientWrapperApi.LATEST_REVISION,
                 test.getPayload(testNumber, testConfig)
         );
         if (deployResponse.getSuccess()) {


### PR DESCRIPTION
 * This will ensure that updates to the argo application won't randomly effect the pipeline deployed
* Maintain one UVN across a pipeline run
 * This will make it easier to group pipeline runs across steps