### PR TITLE
Testing kafka tls

### DIFF
--- a/test_config/atlasinfrastructure.yaml
+++ b/test_config/atlasinfrastructure.yaml
@@ -386,7 +386,7 @@ spec:
             - name: CLIENT_WRAPPER_ENDPOINT
               value: http://atlasclientwrapper.default.svc.cluster.local:9091
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: LOCALHOSTDYNAMICADDRESS:29092
+              value: LOCALHOSTDYNAMICADDRESS:9093
             - name: REDIS_ENDPOINT
               value: redisserver.default.svc.cluster.local:6379
             - name: REPO_SERVER_ENDPOINT
@@ -394,7 +394,14 @@ spec:
           image: atlasworkfloworchestrator
           imagePullPolicy: Never
           name: workfloworchestrator
+          volumeMounts:
+            - mountPath: /tls-cert
+              name: tlscert
           resources: {}
+      volumes:
+        - name: tlscert
+          hostPath:
+            path: /tls-cert
       restartPolicy: Always
 status: {}
 ---

--- a/test_config/docker-compose.yml
+++ b/test_config/docker-compose.yml
@@ -14,13 +14,21 @@ services:
       - zookeeper
     ports:
       - 29092:29092
+      - 9093:9093
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,SSL://kafka:9093, PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT, SSL:SSL, PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_SSL_KEYSTORE_FILENAME: 'certs/kafka.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'certs/sslcred'
+      KAFKA_SSL_KEY_CREDENTIALS: 'certs/sslcred'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'certs/kafka.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'certs/sslcred'
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    volumes:
+      - ./../workfloworchestrator/:/etc/kafka/secrets/certs
 
   workfloworchestrator:
     image: atlasworkfloworchestrator

--- a/workfloworchestrator/src/main/resources/application.yml
+++ b/workfloworchestrator/src/main/resources/application.yml
@@ -1,5 +1,13 @@
 spring:
   kafka:
+    security:
+      protocol: "SSL"
+    ssl:
+      truststore-location: file:/tls-cert/kafka.truststore.jks
+      truststore-password: SS28qmtOJH4OFLUP
+      keystore-location: file:/tls-cert/kafka.keystore.jks
+      keystore-password: SS28qmtOJH4OFLUP
+      key-password: SS28qmtOJH4OFLUP
     producer:
       bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
       key-serializer: org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
@morzhanov These changes seemed to get past the error we were facing earlier today and be able to create the consumer and producer correctly.

Made a few core changes for this test:

- Updated the Dockerfile to add SSL endpoints, also forwarded the 9093 port to localhost (which is how the Workflow Orchestrator interacts with Kafka with SSL). Also updated the port in the Workflow Orchestrator K8S config to be 9093 (might have to be dynamic unless we add SSL as a default).
- Added the keystore and truststore via K8S volume mounting. I mounted a local directory to minikube (https://minikube.sigs.k8s.io/docs/commands/mount/), and then mounted that directory to the Workflow Orchestrator. 
- Only used application.yml file for setting up SSL/configuration.

Results:

Seemed to get past the Keystore access error, but another error is popping up when trying to get a record:
`
Caused by: java.security.cert.CertificateException: No subject alternative names present
`
This is related to the IP/hostname not matching, so it should hopefully be a quick fix.

