### PR TITLE
Write flow for API keys for ClientWrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /util/.gradle/
 /util/build/
 .DS_Store
+/clientwrapper/atlas_operator
+/workflowtrigger/workflowtrigger
+/commanddelegator/command_delegator_api

--- a/cli/cmd/clusterRotateApiKey.go
+++ b/cli/cmd/clusterRotateApiKey.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+
+	// "strconv"
+	"fmt"
+	"net/http"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient"
+	"github.com/argoproj/argo-cd/v2/util/errors"
+	"github.com/argoproj/argo-cd/v2/util/localconfig"
+	"github.com/spf13/cobra"
+)
+
+type ApiKeyType string
+
+const (
+	ApiKeyTypeWorkflowTrigger ApiKeyType = "workflow-trigger"
+	ApiKeyTypeClientWrapper   ApiKeyType = "client-wrapper"
+)
+
+type RotateClusterApiKeyRequest struct {
+	ApiKeyType string
+}
+
+// clusterCreateCmd represents the clusterCreate command
+var clusterRotateApiKeyCmd = &cobra.Command{
+	Use:   "rotate <cluster name>",
+	Short: "rotate cluster api key",
+	Long: `
+Command to rotate cluster's api key. Specify the cluster name and apikey type as arguments.
+Allowed apikey types are: 'workflow-trigger' and 'client-wrapper'.
+
+Example usage:
+	atlas cluster rotate cluster_name workflow-trigger`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 2 {
+			fmt.Println("Invalid number of arguments. Run 'atlas cluster read -h' to see usage details")
+			return
+		}
+
+		clusterName := args[0]
+		apiKeyType := args[1]
+		if apiKeyType != string(ApiKeyTypeWorkflowTrigger) && apiKeyType != string(ApiKeyTypeClientWrapper) {
+			fmt.Println("Invalid apikey type. Run 'atlas cluster rotate -h' to see usage details")
+		}
+
+		defaultLocalConfigPath, err := localconfig.DefaultLocalConfigPath()
+		errors.CheckError(err)
+		config, _ := localconfig.ReadLocalConfig(defaultLocalConfigPath)
+		context, _ := config.ResolveContext(apiclient.ClientOptions{}.Context)
+
+		url := "https://" + atlasURL + "/cluster/" + orgName + "/" + clusterName + "/apikeys/rotate"
+		reqData := &RotateClusterApiKeyRequest{ApiKeyType: apiKeyType}
+		reqBytes, err := json.Marshal(reqData)
+		if err != nil {
+			fmt.Printf("Failed to rotate apikey: %s", err.Error())
+		}
+		req, _ := http.NewRequest("GET", url, bytes.NewBuffer(reqBytes))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", context.User.AuthToken))
+
+		client := getHttpClient()
+		resp, err := client.Do(req)
+		if err != nil {
+			fmt.Println("Request failed with the following error:", err)
+			return
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		statusCode := resp.StatusCode
+		if statusCode == 200 {
+			var resData CreateClusterResponse
+			if err = json.Unmarshal(body, &resData); err != nil {
+				fmt.Printf("Error rotating cluster apikey: %s", err.Error())
+			}
+			fmt.Printf("Successfully rotated apikey of type %s for cluster %s of org %s. New apikey is '%s'", apiKeyType, clusterName, orgName, resData.ApiKey)
+		} else {
+			fmt.Printf("Error rotating cluster apikey: %d - %s", statusCode, string(body))
+		}
+	},
+}
+
+func init() {
+	clusterCmd.AddCommand(clusterRotateApiKeyCmd)
+}

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -345,7 +345,7 @@ func oauth2Login(ctx context.Context, port int, oidcSettings *settingspkg.OIDCCo
 	defer cancel()
 	_ = srv.Shutdown(ctx)
 	log.Debugf("Token: %s", tokenString)
-	log.Debugf("Refresh Token: %s", refreshToken)
+	log.Debugf("Rotate Token: %s", refreshToken)
 	return tokenString, refreshToken
 }
 

--- a/clientwrapper/apikeysmanager/apikeysmanager.go
+++ b/clientwrapper/apikeysmanager/apikeysmanager.go
@@ -32,7 +32,7 @@ func (m *manager) GetApiKey() string {
 }
 
 func (m *manager) WatchApiKey() error {
-	return m.client.WatchApiKeySecret(func(_ kubernetesclient.SecretChangeType, secret *v1.Secret) {
+	return m.client.WatchApiKeySecret(m.secretName, func(_ kubernetesclient.SecretChangeType, secret *v1.Secret) {
 		m.apikey = string(secret.Data[kubernetesclient.SecretsKeyName])
 	})
 }

--- a/clientwrapper/apikeysmanager/apikeysmanager.go
+++ b/clientwrapper/apikeysmanager/apikeysmanager.go
@@ -1,0 +1,38 @@
+package apikeysmanager
+
+import (
+	"github.com/greenopsinc/util/apikeys"
+	"github.com/greenopsinc/util/kubernetesclient"
+	v1 "k8s.io/api/core/v1"
+)
+
+type Manager interface {
+	GetApiKey() string
+	WatchApiKey() error
+}
+
+type manager struct {
+	apikey     string
+	secretName string
+	client     apikeys.Client
+}
+
+func New(secretName string, kubernetesClient kubernetesclient.KubernetesClient) (Manager, error) {
+	m := &manager{secretName: secretName, client: apikeys.New(kubernetesClient)}
+	apikey, err := m.client.GetOne(m.secretName)
+	if err != nil {
+		return nil, err
+	}
+	m.apikey = apikey
+	return m, nil
+}
+
+func (m *manager) GetApiKey() string {
+	return m.apikey
+}
+
+func (m *manager) WatchApiKey() error {
+	return m.client.WatchApiKeySecret(func(_ kubernetesclient.SecretChangeType, secret *v1.Secret) {
+		m.apikey = string(secret.Data[kubernetesclient.SecretsKeyName])
+	})
+}

--- a/commanddelegator/command_delegator_api.go
+++ b/commanddelegator/command_delegator_api.go
@@ -23,7 +23,7 @@ import (
 const (
 	orgNameField     string = "orgName"
 	clusterNameField string = "clusterName"
-	apiKeyHeaderName        = "api-key"
+	apiKeyHeaderName        = "X-Api-Key"
 )
 
 type apiClient struct {
@@ -35,10 +35,6 @@ type apiClient struct {
 	emptyClientRequestPacketStruct clientrequest.ClientRequestPacket
 }
 
-var dbOperator db.DbOperator
-var emptyClusterStruct = cluster.ClusterSchema{}
-var emptyClientRequestPacketStruct = clientrequest.ClientRequestPacket{}
-
 func main() {
 	kclient := kubernetesclient.New()
 	api := &apiClient{
@@ -49,7 +45,8 @@ func main() {
 		emptyClusterStruct:             cluster.ClusterSchema{},
 		emptyClientRequestPacketStruct: clientrequest.ClientRequestPacket{},
 	}
-	InitEndpoints(api.router)
+	api.apikeysClient.GetAll()
+	api.InitEndpoints(api.router)
 	api.router.Use(api.ApiKeysMiddleware)
 	if err := api.apikeysClient.WatchApiKeys(); err != nil {
 		log.Fatal(err)
@@ -57,12 +54,12 @@ func main() {
 	httpserver.CreateAndWatchServer(tlsmanager.ClientCommandDelegator, api.tlsManager, api.router)
 }
 
-func InitEndpoints(r *mux.Router) {
-	r.HandleFunc("/requests/{orgName}/{clusterName}", getCommands).Methods("GET")
-	r.HandleFunc("/requests/ackHead/{orgName}/{clusterName}", ackHeadOfRequestList).Methods("DELETE")
-	r.HandleFunc("/notifications/{orgName}/{clusterName}", addNotificationCommand).Methods("POST")
-	r.HandleFunc("/notifications/ackHead/{orgName}/{clusterName}", ackHeadOfNotificationList).Methods("DELETE")
-	r.HandleFunc("/requests/retry/{orgName}/{clusterName}", retryMessage).Methods("DELETE")
+func (a *apiClient) InitEndpoints(r *mux.Router) {
+	r.HandleFunc("/requests/{orgName}/{clusterName}", a.getCommands).Methods("GET")
+	r.HandleFunc("/requests/ackHead/{orgName}/{clusterName}", a.ackHeadOfRequestList).Methods("DELETE")
+	r.HandleFunc("/notifications/{orgName}/{clusterName}", a.addNotificationCommand).Methods("POST")
+	r.HandleFunc("/notifications/ackHead/{orgName}/{clusterName}", a.ackHeadOfNotificationList).Methods("DELETE")
+	r.HandleFunc("/requests/retry/{orgName}/{clusterName}", a.retryMessage).Methods("DELETE")
 }
 
 func (a *apiClient) ApiKeysMiddleware(next http.Handler) http.Handler {
@@ -81,29 +78,29 @@ func (a *apiClient) ApiKeysMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func retryMessage(w http.ResponseWriter, r *http.Request) {
+func (a *apiClient) retryMessage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	orgName := vars[orgNameField]
 	clusterName := vars[clusterNameField]
-	dbClient := dbOperator.GetClient()
+	dbClient := a.dbOperator.GetClient()
 	defer dbClient.Close()
 
 	clusterKey := db.MakeDbClusterKey(orgName, clusterName)
 	clusterSchema := dbClient.FetchClusterSchemaTransactionless(clusterKey)
-	if clusterSchema == emptyClusterStruct {
+	if clusterSchema == a.emptyClusterStruct {
 		http.Error(w, "Cluster was nil", http.StatusBadRequest)
 		return
 	}
 	key := db.MakeClientRequestQueueKey(orgName, clusterName)
 	clientRequestPacket := dbClient.FetchHeadInClientRequestList(key)
-	if clientRequestPacket != emptyClientRequestPacketStruct {
+	if clientRequestPacket != a.emptyClientRequestPacketStruct {
 		clientRequestPacket.RetryCount = clientRequestPacket.RetryCount + 1
 	}
 	dbClient.InsertValueInTransactionlessList(key, clientRequestPacket)
 	dbClient.UpdateHeadInTransactionlessList(key, nil)
 }
 
-func writeResponse(w http.ResponseWriter, i interface{}) {
+func (a *apiClient) writeResponse(w http.ResponseWriter, i interface{}) {
 	if i != nil {
 		payload := serializer.Serialize(i)
 		w.Write([]byte(payload))
@@ -111,16 +108,16 @@ func writeResponse(w http.ResponseWriter, i interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 }
 
-func getCommands(w http.ResponseWriter, r *http.Request) {
+func (a *apiClient) getCommands(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	orgName := vars[orgNameField]
 	clusterName := vars[clusterNameField]
-	dbClient := dbOperator.GetClient()
+	dbClient := a.dbOperator.GetClient()
 	defer dbClient.Close()
 
 	clusterKey := db.MakeDbClusterKey(orgName, clusterName)
 	clusterSchema := dbClient.FetchClusterSchemaTransactionless(clusterKey)
-	if clusterSchema == emptyClusterStruct {
+	if clusterSchema == a.emptyClusterStruct {
 		http.Error(w, "Cluster was nil", http.StatusBadRequest)
 		return
 	}
@@ -131,38 +128,38 @@ func getCommands(w http.ResponseWriter, r *http.Request) {
 	//Notifications are from the management plane, they take priority over basic processing
 	//Notifications also do not change the state of deployments and clusters, so can be processed even when in a no-deploy state
 	clientNotificationHead := dbClient.FetchHeadInClientRequestList(notificationQueueKey)
-	if clientNotificationHead != emptyClientRequestPacketStruct {
+	if clientNotificationHead != a.emptyClientRequestPacketStruct {
 		//Notifications don't subscribe to the retry/final try logic, the client wrapper makes sure it's only run once
-		writeResponse(w, []clientrequest.ClientRequestEvent{clientNotificationHead.ClientRequest})
+		a.writeResponse(w, []clientrequest.ClientRequestEvent{clientNotificationHead.ClientRequest})
 		return
 	}
 	if noDeployInfo != nil && noDeployInfo.Namespace == "" {
-		writeResponse(w, nil)
+		a.writeResponse(w, nil)
 		return
 	}
 	clientRequestPacket := dbClient.FetchHeadInClientRequestList(requestQueueKey)
-	if clientRequestPacket != emptyClientRequestPacketStruct {
+	if clientRequestPacket != a.emptyClientRequestPacketStruct {
 		if noDeployInfo != nil && clientRequestPacket.Namespace == noDeployInfo.Namespace {
-			writeResponse(w, nil)
+			a.writeResponse(w, nil)
 			return
 		}
 		request := clientRequestPacket.ClientRequest
 		request.SetFinalTry(clientRequestPacket.RetryCount >= 5)
-		writeResponse(w, []clientrequest.ClientRequestEvent{request})
+		a.writeResponse(w, []clientrequest.ClientRequestEvent{request})
 		return
 	}
 }
 
-func ackHeadOfRequestList(w http.ResponseWriter, r *http.Request) {
+func (a *apiClient) ackHeadOfRequestList(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	orgName := vars[orgNameField]
 	clusterName := vars[clusterNameField]
-	dbClient := dbOperator.GetClient()
+	dbClient := a.dbOperator.GetClient()
 	defer dbClient.Close()
 
 	clusterKey := db.MakeDbClusterKey(orgName, clusterName)
 	clusterSchema := dbClient.FetchClusterSchemaTransactionless(clusterKey)
-	if clusterSchema == emptyClusterStruct {
+	if clusterSchema == a.emptyClusterStruct {
 		http.Error(w, "Cluster was nil", http.StatusBadRequest)
 		return
 	}
@@ -170,16 +167,16 @@ func ackHeadOfRequestList(w http.ResponseWriter, r *http.Request) {
 	dbClient.UpdateHeadInTransactionlessList(key, nil)
 }
 
-func addNotificationCommand(w http.ResponseWriter, r *http.Request) {
+func (a *apiClient) addNotificationCommand(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	orgName := vars[orgNameField]
 	clusterName := vars[clusterNameField]
-	dbClient := dbOperator.GetClient()
+	dbClient := a.dbOperator.GetClient()
 	defer dbClient.Close()
 
 	clusterKey := db.MakeDbClusterKey(orgName, clusterName)
 	clusterSchema := dbClient.FetchClusterSchemaTransactionless(clusterKey)
-	if clusterSchema == emptyClusterStruct {
+	if clusterSchema == a.emptyClusterStruct {
 		http.Error(w, "Cluster was nil", http.StatusBadRequest)
 		return
 	}
@@ -199,19 +196,19 @@ func addNotificationCommand(w http.ResponseWriter, r *http.Request) {
 		ClientRequest: notification,
 	})
 
-	writeResponse(w, requestId)
+	a.writeResponse(w, requestId)
 }
 
-func ackHeadOfNotificationList(w http.ResponseWriter, r *http.Request) {
+func (a *apiClient) ackHeadOfNotificationList(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	orgName := vars[orgNameField]
 	clusterName := vars[clusterNameField]
-	dbClient := dbOperator.GetClient()
+	dbClient := a.dbOperator.GetClient()
 	defer dbClient.Close()
 
 	clusterKey := db.MakeDbClusterKey(orgName, clusterName)
 	clusterSchema := dbClient.FetchClusterSchemaTransactionless(clusterKey)
-	if clusterSchema == emptyClusterStruct {
+	if clusterSchema == a.emptyClusterStruct {
 		http.Error(w, "Cluster was nil", http.StatusBadRequest)
 		return
 	}

--- a/test_config/atlasinfrastructure.yaml
+++ b/test_config/atlasinfrastructure.yaml
@@ -1,179 +1,81 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: workflowtrigger
+    app.kubernetes.io/name: workflowtrigger
+    app.kubernetes.io/part-of: atlas
+  name: workflowtrigger
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: reposerver
+    app.kubernetes.io/name: reposerver
+    app.kubernetes.io/part-of: atlas
+  name: reposerver
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: workfloworchestrator
+    app.kubernetes.io/name: workfloworchestrator
+    app.kubernetes.io/part-of: atlas
+  name: workfloworchestrator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: commanddelegator
+    app.kubernetes.io/name: commanddelegator
+    app.kubernetes.io/part-of: atlas
+  name: commanddelegator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: clientwrapper
+    app.kubernetes.io/name: clientwrapper
+    app.kubernetes.io/part-of: atlas
+  name: clientwrapper
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prom-admin
-  namespace: default
+  name: atlas
 rules:
-  # Small scope, feel free to change it
-  - apiGroups: ["networking.istio.io", "apps", "", "batch", "core"]
-    resources: ["*"] #"pods", "nodes"
-    verbs: ["*"] #"get", "watch", "list"
-
+  - apiGroups: ["networking.istio.io", "apps", "", "batch", "core", "*"]
+    resources: ["*"]
+    verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prom-rbac
+  name: atlas-clusterrolebinding
 subjects:
   - kind: ServiceAccount
-    name: default
-    namespace: default
+    name: workflowtrigger
+    namespace: atlas
+  - kind: ServiceAccount
+    name: reposerver
+    namespace: atlas
+  - kind: ServiceAccount
+    name: workfloworchestrator
+    namespace: atlas
+  - kind: ServiceAccount
+    name: commanddelegator
+    namespace: atlas
+  - kind: ServiceAccount
+    name: clientwrapper
+    namespace: atlas
 roleRef:
   kind: ClusterRole
-  name: prom-admin
+  name: atlas
   apiGroup: rbac.authorization.k8s.io
-#---
-#apiVersion: apps/v1
-#kind: Deployment
-#metadata:
-#  labels:
-#    app: dex
-#  name: dex
-#  namespace: default
-#spec:
-#  replicas: 1
-#  selector:
-#    matchLabels:
-#      app: dex
-#  template:
-#    metadata:
-#      labels:
-#        app: dex
-#    spec:
-#      serviceAccountName: dex # This is created below
-#      containers:
-#        - image: dexidp/dex:v2.27.0 #or quay.io/dexidp/dex:v2.26.0
-#          name: dex
-#          command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
-#
-#          ports:
-#            - name: https
-#              containerPort: 5556
-#
-#          volumeMounts:
-#            - name: config
-#              mountPath: /etc/dex/cfg
-#            - name: tls
-#              mountPath: /etc/dex/tls
-#
-#          env:
-#            - name: GITHUB_CLIENT_ID
-#              valueFrom:
-#                secretKeyRef:
-#                  name: github-client
-#                  key: client-id
-#            - name: GITHUB_CLIENT_SECRET
-#              valueFrom:
-#                secretKeyRef:
-#                  name: github-client
-#                  key: client-secret
-#
-#          readinessProbe:
-#            httpGet:
-#              path: /healthz
-#              port: 5556
-#              scheme: HTTPS
-#      volumes:
-#        - name: config
-#          configMap:
-#            name: dex
-#            items:
-#              - key: config.yaml
-#                path: config.yaml
-#        - name: tls
-#          secret:
-#            secretName: dex.example.com.tls
-#---
-#kind: ConfigMap
-#apiVersion: v1
-#metadata:
-#  name: dex
-#  namespace: default
-#data:
-##  This configmap is temporary. We should be dynamically adding this info for dex. "Example App" should be replaced with Atlas' info
-#  config.yaml: |
-#    issuer: https://localhost:32000
-#    storage:
-#      type: kubernetes
-#      config:
-#        inCluster: true
-#    web:
-#      https: 0.0.0.0:5556
-#      tlsCert: /etc/dex/tls/tls.crt
-#      tlsKey: /etc/dex/tls/tls.key
-#    connectors:
-#    - type: github
-#      id: github
-#      name: GitHub
-#      config:
-#        clientID: 165aae46cd0bc4673c8f
-#        clientSecret: d7f4988472b85ff08fa3c789fb385d53c5e90abd
-#        redirectURI: https://localhost:32000/callback
-#        org: kubernetes
-#    oauth2:
-#      skipApprovalScreen: true
-#    staticClients:
-#    - id: example-app
-#      redirectURIs:
-#      - 'https://localhost:5555/callback'
-#      name: 'Example App'
-#      secret: ZXhhbXBsZS1hcHAtc2VjcmV0
-#    enablePasswordDB: true
-#    staticPasswords:
-#    - email: "admin@example.com"
-#      # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
-#      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-#      username: "admin"
-#      userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
-#---
-#apiVersion: v1
-#kind: Service
-#metadata:
-#  name: dex
-#  namespace: default
-#spec:
-#  type: NodePort
-#  ports:
-#    - name: dex
-#      port: 5556
-#      protocol: TCP
-#      targetPort: 5556
-#      nodePort: 32000
-#  selector:
-#    app: dex
-#---
-#apiVersion: v1
-#kind: ServiceAccount
-#metadata:
-#  labels:
-#    app: dex
-#  name: dex
-#  namespace: default
-#---
-#apiVersion: rbac.authorization.k8s.io/v1
-#kind: ClusterRole
-#metadata:
-#  name: dex
-#rules:
-#  - apiGroups: ["dex.coreos.com"] # API group created by dex
-#    resources: ["*"]
-#    verbs: ["*"]
-#  - apiGroups: ["apiextensions.k8s.io"]
-#    resources: ["customresourcedefinitions"]
-#    verbs: ["create"] # To manage its own resources, dex must be able to create customresourcedefinitions
-#---
-#apiVersion: rbac.authorization.k8s.io/v1
-#kind: ClusterRoleBinding
-#metadata:
-#  name: dex
-#roleRef:
-#  apiGroup: rbac.authorization.k8s.io
-#  kind: ClusterRole
-#  name: dex
-#subjects:
-#  - kind: ServiceAccount
-#    name: dex           # Service account assigned to the dex pod, created above
-#    namespace: default  # The namespace dex is running in
 ---
 #Redis Service & Deployment
 apiVersion: v1
@@ -261,6 +163,8 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: workflowtrigger
+    app.kubernetes.io/name: workflowtrigger
+    app.kubernetes.io/part-of: atlas
   name: workflowtrigger
 spec:
   replicas: 1
@@ -296,6 +200,7 @@ spec:
             - containerPort: 8080
           resources: {}
       restartPolicy: Always
+      serviceAccountName: workflowtrigger
 status: {}
 ---
 #PipelineRepoServer Service & Deployment
@@ -328,6 +233,8 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: reposerver
+    app.kubernetes.io/name: reposerver
+    app.kubernetes.io/part-of: atlas
   name: reposerver
 spec:
   replicas: 1
@@ -357,6 +264,7 @@ spec:
             - containerPort: 8080
           resources: {}
       restartPolicy: Always
+      serviceAccountName: reposerver
 status: {}
 ---
 #WorkflowOrchestrator Deployment
@@ -369,6 +277,8 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: workfloworchestrator
+    app.kubernetes.io/name: workfloworchestrator
+    app.kubernetes.io/part-of: atlas
   name: workfloworchestrator
 spec:
   replicas: 1
@@ -409,6 +319,7 @@ spec:
           hostPath:
             path: /tls-cert
       restartPolicy: Always
+      serviceAccountName: workfloworchestrator
 status: {}
 ---
 #CommandDelegator Service & Deployment
@@ -441,6 +352,8 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: commanddelegator
+    app.kubernetes.io/name: commanddelegator
+    app.kubernetes.io/part-of: atlas
   name: commanddelegator
 spec:
   replicas: 1
@@ -468,46 +381,50 @@ spec:
             - containerPort: 8080
           resources: {}
       restartPolicy: Always
+      serviceAccountName: commanddelegator
 status: {}
 ---
 # ClientWrapper Service & Deployment
 apiVersion: v1
 kind: Service
 metadata:
-  name: atlasclientwrapper
+  name: clientwrapper
   labels:
-    app: atlasclientwrapper
+    app: clientwrapper
 spec:
   ports:
     - port: 9091
       targetPort: 9091
   type: LoadBalancer
   selector:
-    app: atlasclientwrapper
+    app: clientwrapper
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: atlasclientwrapper
+  name: clientwrapper
   labels:
-    app: atlasclientwrapper
+    app: clientwrapper
+    app.kubernetes.io/name: clientwrapper
+    app.kubernetes.io/part-of: atlas
 spec:
   selector:
     matchLabels:
-      app: atlasclientwrapper
+      app: clientwrapper
   replicas: 1
   template:
     metadata:
       labels:
-        app: atlasclientwrapper
+        app: clientwrapper
     spec:
+      serviceAccountName: clientwrapper
       containers:
         - env:
           - name: WORKFLOW_TRIGGER_SERVER_ADDR
             value: https://workflowtrigger.atlas.svc.cluster.local:8080
           - name: COMMAND_DELEGATOR_URL
             value: https://commanddelegator.atlas.svc.cluster.local:8080
-          name: atlasclientwrapper
+          name: clientwrapper
           image: atlasclientwrapper
           imagePullPolicy: Never
           resources:

--- a/test_config/atlasinfrastructure_gke.yaml
+++ b/test_config/atlasinfrastructure_gke.yaml
@@ -15,8 +15,8 @@ metadata:
   name: prom-rbac
 subjects:
   - kind: ServiceAccount
-    name: default
-    namespace: default
+    name: atlas
+    namespace: atlas
 roleRef:
   kind: ClusterRole
   name: prom-admin
@@ -254,11 +254,11 @@ spec:
       containers:
         - env:
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: kafka-service.default.svc.cluster.local:9092
+              value: kafka-service.atlas.svc.cluster.local:9092
             - name: REDIS_ENDPOINT
-              value: redisserver.default.svc.cluster.local:6379
+              value: redisserver.atlas.svc.cluster.local:6379
             - name: REPO_SERVER_ENDPOINT
-              value: http://reposerver.default.svc.cluster.local:8080
+              value: http://reposerver.atlas.svc.cluster.local:8080
           image: gcr.io/greenops-dev/atlasworkflowtrigger
 #          imagePullPolicy: Never
           name: workflowtrigger
@@ -317,7 +317,7 @@ spec:
       containers:
         - env:
             - name: REDIS_ENDPOINT
-              value: redisserver.default.svc.cluster.local:6379
+              value: redisserver.atlas.svc.cluster.local:6379
           image: gcr.io/greenops-dev/atlasreposerver
 #          imagePullPolicy: Never
           name: reposerver
@@ -356,13 +356,13 @@ spec:
       containers:
         - env:
             - name: CLIENT_WRAPPER_ENDPOINT
-              value: https://atlasclientwrapper.default.svc.cluster.local:9091
+              value: https://atlasclientwrapper.atlas.svc.cluster.local:9091
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: kafka-service.default.svc.cluster.local:9092
+              value: kafka-service.atlas.svc.cluster.local:9092
             - name: REDIS_ENDPOINT
-              value: redisserver.default.svc.cluster.local:6379
+              value: redisserver.atlas.svc.cluster.local:6379
             - name: REPO_SERVER_ENDPOINT
-              value: http://reposerver.default.svc.cluster.local:8080
+              value: http://reposerver.atlas.svc.cluster.local:8080
           image: gcr.io/greenops-dev/atlasworkfloworchestrator
 #          imagePullPolicy: Never
           name: workfloworchestrator

--- a/test_config/deploy_kubernetes_test.sh
+++ b/test_config/deploy_kubernetes_test.sh
@@ -6,7 +6,7 @@ then
   minikube start
 fi
 docker compose down
-kubectl delete -f atlasinfrastructure.yaml
+kubectl delete -f atlasinfrastructure.yaml -n atlas
 localhostip="$(minikube ssh 'grep host.minikube.internal /etc/hosts | cut -f1')"
 localhostip=$(echo "$localhostip" | tr -d '\r')
 perl -p -e "s/localhost/$localhostip/g" docker-compose.yml | docker compose -f - up -d zookeeper kafka
@@ -22,10 +22,10 @@ cd ../clientwrapper
 env GOOS=linux go build -v ./atlasoperator/atlas_operator.go
 docker build -f test/Dockerfile -t atlasclientwrapper .
 minikube image load atlasclientwrapper
-cd ../PipelineRepoServer/
+cd ../pipelinereposerver/
 ./gradlew jibDockerBuild --image=atlasreposerver
 minikube image load atlasreposerver
-cd ../WorkflowOrchestrator/
+cd ../workfloworchestrator/
 ./gradlew jibDockerBuild --image=atlasworkfloworchestrator
 minikube image load atlasworkfloworchestrator
 cd ../test_config

--- a/utilgo/apikeys/apikeys.go
+++ b/utilgo/apikeys/apikeys.go
@@ -1,0 +1,58 @@
+package apikeys
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/greenopsinc/util/rand"
+)
+
+// create cluster method in wt will generate api key and send it to user
+// single api key for cluster will secure cd and wt
+// create refresh method which will rotate api key
+// by default we will have default api key
+// api key should only secure generate enpoint
+// api key should secure all endpoints
+// refresh api key method should be secured by argocd acess token
+// refresh api key method should has cluster name\id parameters
+
+// create api keys for each client: wt, cluster1 cw, cluster2 cw, etc.
+// user should put cw in a secret and get `atlas-client-wrapper-apikey` `atlas-workflow-trigger-apikey`
+
+// TODO: seems like we need to store two secrets: for workflow trigger and for command delegator
+
+// TODO: how should we generate/rotate api keys (which api communication method to use)?
+//		1. use http api call to service (not applicable as we need to somehow secure it)
+//		2. use cli+workflowtrigger to generate/rotate secrets and api keys for services
+//			guess thesis good option as cli and wt secured with argocd auth
+
+// TODO: "When a user desires, they can query for a new token (on a per cluster basis), which should retire the cluster's old access token and provide a new one. This will require an API method."
+//		In this case we cannot use a simple hash with secret and we have two options:
+//			1. create a blacklist or whitelist of used/allowed api keys
+//			2. rotate a secret each time when user wants to generate new api key
+
+// TODO: where we should store secrets for api keys:
+//		1. env vars
+//		2. kubernetes secrets
+//		3. redis
+
+func Generate(secret string) (string, error) {
+	h := hmac.New(sha256.New, []byte(secret))
+	data, err := rand.RandomString(64)
+	if err != nil {
+		return "", err
+	}
+	h.Write([]byte(data))
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func Verify(hash, secret string) (bool, error) {
+	sig, err := hex.DecodeString(hash)
+	if err != nil {
+		return false, err
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(secret))
+	return hmac.Equal(sig, mac.Sum(nil)), nil
+}

--- a/utilgo/apikeys/client.go
+++ b/utilgo/apikeys/client.go
@@ -12,38 +12,6 @@ import (
 	"github.com/greenopsinc/util/rand"
 )
 
-// create cluster method in wt will generate api key and send it to user
-// single api key for cluster will secure cd and wt
-// create refresh method which will rotate api key
-// by default we will have default api key
-// api key should only secure generate enpoint on wt
-// api key should secure all endpoints on cd
-// refresh api key method should be secured by argocd acess token
-// refresh api key method should has cluster name\id parameters
-
-// create api keys for each client: wt, cluster1 cw, cluster2 cw, etc.
-// user should put cw in a secret and get `atlas-client-wrapper-apikey` `atlas-workflow-trigger-apikey`
-
-// TODO: seems like we need to store two secrets: for workflow trigger and for command delegator
-
-// TODO: how should we generate/rotate api keys (which api communication method to use)?
-//		1. use http api call to service (not applicable as we need to somehow secure it)
-//		2. use cli+workflowtrigger to generate/rotate secrets and api keys for services
-//			guess thesis good option as cli and wt secured with argocd auth
-
-// TODO: "When a user desires, they can query for a new token (on a per cluster basis), which should retire the cluster's old access token and provide a new one. This will require an API method."
-//		In this case we cannot use a simple hash with secret and we have two options:
-//			1. create a blacklist or whitelist of used/allowed api keys
-//			2. rotate a secret each time when user wants to generate new api key
-
-// TODO: where we should store secrets for api keys:
-//		1. env vars
-//		2. kubernetes secrets
-//		3. redis
-
-// TODO: use a single secret for all apikeys
-//		add listener on wt and cd to listen for apikeys secret
-
 const ATLAS_NAMESPACE = "atlas"
 
 type Client interface {
@@ -53,7 +21,7 @@ type Client interface {
 	Verify(apikey string) (bool, error)
 	Rotate(name string) (string, error)
 	WatchApiKeys() error
-	WatchApiKeySecret(handler kubernetesclient.WatchSecretHandler) error
+	WatchApiKeySecret(name string, handler kubernetesclient.WatchSecretHandler) error
 }
 
 type client struct {
@@ -62,13 +30,7 @@ type client struct {
 }
 
 func New(kclient kubernetesclient.KubernetesClient) Client {
-	c := &client{kclient: kclient}
-	keys := c.kclient.FetchApiKeys(ATLAS_NAMESPACE)
-	if keys == nil {
-		keys = make(map[string]string, 0)
-	}
-	c.apikeys = keys
-	return c
+	return &client{kclient: kclient}
 }
 
 func (c *client) WatchApiKeys() error {
@@ -81,8 +43,8 @@ func (c *client) WatchApiKeys() error {
 	})
 }
 
-func (c *client) WatchApiKeySecret(handler kubernetesclient.WatchSecretHandler) error {
-	return c.kclient.WatchSecretData(context.Background(), kubernetesclient.ApikeysSecretName, ATLAS_NAMESPACE, handler)
+func (c *client) WatchApiKeySecret(name string, handler kubernetesclient.WatchSecretHandler) error {
+	return c.kclient.WatchSecretData(context.Background(), name, ATLAS_NAMESPACE, handler)
 }
 
 func (c *client) Issue(name string) (string, error) {

--- a/utilgo/apikeys/client.go
+++ b/utilgo/apikeys/client.go
@@ -42,8 +42,8 @@ const ATLAS_NAMESPACE = "atlas"
 type Client interface {
 	Issue(name string) (string, error)
 	Get(name string) (string, error)
-	Verify(apikey string) (bool, error)
-	Refresh(name string) (string, error)
+	Verify(apikey string, name string) (bool, error)
+	Rotate(name string) (string, error)
 }
 
 type client struct {
@@ -74,8 +74,8 @@ func (c *client) Get(name string) (string, error) {
 	return apikey, nil
 }
 
-func (c *client) Verify(apikey string) (bool, error) {
-	existing, err := c.Get(apikey)
+func (c *client) Verify(apikey string, name string) (bool, error) {
+	existing, err := c.Get(name)
 	if err != nil {
 		return false, err
 	}
@@ -88,6 +88,6 @@ func (c *client) Verify(apikey string) (bool, error) {
 	return true, nil
 }
 
-func (c *client) Refresh(name string) (string, error) {
+func (c *client) Rotate(name string) (string, error) {
 	return c.Issue(name)
 }

--- a/utilgo/kubernetesclient/kubernetes_client.go
+++ b/utilgo/kubernetesclient/kubernetes_client.go
@@ -2,6 +2,7 @@ package kubernetesclient
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"strings"
 	"time"
@@ -20,8 +21,9 @@ import (
 )
 
 const (
-	secretsKeyName   string = "data"
-	gitCredNamespace string = "gitcred"
+	gitCredNamespace  = "gitcred"
+	SecretsKeyName    = "data"
+	ApikeysSecretName = "atlas-apikeys"
 )
 
 type SecretChangeType int8
@@ -44,6 +46,7 @@ type KubernetesClient interface {
 	StoreApiKey(apikey string, name string, namespace string) bool
 	FetchGitCred(name string) git.GitCred
 	FetchApiKey(name string, namespace string) string
+	FetchApiKeys(namespace string) map[string]string
 	FetchSecretData(name string, namespace string) *v1.Secret
 	WatchSecretData(ctx context.Context, name string, namespace string, handler WatchSecretHandler) error
 }
@@ -87,22 +90,25 @@ func (k KubernetesClientDriver) StoreGitCred(gitCred git.GitCred, name string) b
 }
 
 func (k KubernetesClientDriver) StoreApiKey(apikey string, name string, namespace string) bool {
-	var err error
-	if apikey == "" {
-		err = k.storeSecret(nil, namespace, name)
+	var apikeys map[string]string
+	apikeysSecret := k.readSecret(namespace, ApikeysSecretName)
+	if apikeysSecret == nil || apikeysSecret.Data == nil || apikeysSecret.Data[SecretsKeyName] == nil {
+		apikeys = make(map[string]string, 1)
 	} else {
-		err = k.storeSecret(apikey, namespace, name)
+		if err := json.Unmarshal(apikeysSecret.Data[SecretsKeyName], &apikeys); err != nil {
+			return false
+		}
 	}
-	if err != nil {
-		return false
-	}
-	return true
+
+	apikeys[name] = apikey
+	err := k.storeSecret(apikeys, namespace, name)
+	return err == nil
 }
 
 func (k KubernetesClientDriver) FetchGitCred(name string) git.GitCred {
 	secret := k.readSecret(gitCredNamespace, name)
 	if secret != nil {
-		if val, ok := secret.StringData[secretsKeyName]; ok {
+		if val, ok := secret.StringData[SecretsKeyName]; ok {
 			return git.UnmarshallGitCredString(val)
 		}
 		return nil
@@ -110,13 +116,29 @@ func (k KubernetesClientDriver) FetchGitCred(name string) git.GitCred {
 	return nil
 }
 
+func (k KubernetesClientDriver) FetchApiKeys(namespace string) map[string]string {
+	secret := k.readSecret(namespace, ApikeysSecretName)
+	if secret == nil {
+		return nil
+	}
+	val, ok := secret.StringData[SecretsKeyName]
+	if !ok {
+		return nil
+	}
+	var res map[string]string
+	if err := json.Unmarshal([]byte(val), &res); err != nil {
+		return nil
+	}
+	return res
+}
+
 func (k KubernetesClientDriver) FetchApiKey(name string, namespace string) string {
 	secret := k.readSecret(namespace, name)
-	if secret != nil {
-		if val, ok := secret.StringData[secretsKeyName]; ok {
-			return val
-		}
+	if secret == nil {
 		return ""
+	}
+	if val, ok := secret.StringData[SecretsKeyName]; ok {
+		return val
 	}
 	return ""
 }
@@ -253,7 +275,7 @@ func makeSecret(object interface{}, namespace string, name string) *corev1.Secre
 			Name:      name,
 			Namespace: namespace,
 		},
-		StringData: map[string]string{secretsKeyName: string(objectBytes)},
+		StringData: map[string]string{SecretsKeyName: string(objectBytes)},
 		Type:       "Opaque",
 	}
 }

--- a/utilgo/rand/rand.go
+++ b/utilgo/rand/rand.go
@@ -1,0 +1,19 @@
+package rand
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+func RandomString(n int) (string, error) {
+	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+	ret := make([]byte, n)
+	for i := 0; i < n; i++ {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			return "", err
+		}
+		ret[i] = letters[num.Int64()]
+	}
+	return string(ret), nil
+}

--- a/utilgo/rand/rand.go
+++ b/utilgo/rand/rand.go
@@ -6,7 +6,7 @@ import (
 )
 
 func RandomString(n int) (string, error) {
-	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-#$^*&"
 	ret := make([]byte, n)
 	for i := 0; i < n; i++ {
 		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))

--- a/utilgo/tlsmanager/tlsmanager.go
+++ b/utilgo/tlsmanager/tlsmanager.go
@@ -39,10 +39,10 @@ type tlsManager struct {
 }
 
 const (
-	NamespaceDefault string = "default"
-	NamespaceArgoCD  string = "argocd"
-	CompanyName      string = "Atlas"
-	CountryName      string = "US"
+	AtlasNamespace  string = "atlas"
+	NamespaceArgoCD string = "argocd"
+	CompanyName     string = "Atlas"
+	CountryName     string = "US"
 )
 
 type TLSSecretName string
@@ -128,7 +128,7 @@ func (m *tlsManager) GetClientCertPEM(clientName ClientName) ([]byte, error) {
 		return nil, err
 	}
 
-	secret := m.k.FetchSecretData(string(secretName), NamespaceDefault)
+	secret := m.k.FetchSecretData(string(secretName), AtlasNamespace)
 	if secret == nil || len(secret.Data) == 0 {
 		return nil, nil
 	}
@@ -146,7 +146,7 @@ func (m *tlsManager) GetKafkaTLSConf() (*tls.Config, error) {
 		return nil, err
 	}
 
-	secret := m.k.FetchSecretData(string(secretName), NamespaceDefault)
+	secret := m.k.FetchSecretData(string(secretName), AtlasNamespace)
 	if secret == nil || len(secret.Data) == 0 {
 		return &tls.Config{InsecureSkipVerify: true}, nil
 	}
@@ -166,7 +166,7 @@ func (m *tlsManager) WatchServerTLSConf(serverName ClientName, handler func(conf
 	}
 
 	ctx := context.Background()
-	return m.k.WatchSecretData(ctx, string(secretName), NamespaceDefault, func(t kclient.SecretChangeType, secret *corev1.Secret) {
+	return m.k.WatchSecretData(ctx, string(secretName), AtlasNamespace, func(t kclient.SecretChangeType, secret *corev1.Secret) {
 		var (
 			config   *tls.Config
 			err      error
@@ -210,7 +210,7 @@ func (m *tlsManager) WatchClientTLSConf(clientName ClientName, handler func(conf
 	}
 
 	ctx := context.Background()
-	return m.k.WatchSecretData(ctx, string(secretName), NamespaceDefault, func(t kclient.SecretChangeType, secret *corev1.Secret) {
+	return m.k.WatchSecretData(ctx, string(secretName), AtlasNamespace, func(t kclient.SecretChangeType, secret *corev1.Secret) {
 		switch t {
 		case kclient.SecretChangeTypeAdd:
 			fallthrough
@@ -274,7 +274,7 @@ func (m *tlsManager) WatchKafkaTLSConf(handler func(config *tls.Config, err erro
 	}
 
 	ctx := context.Background()
-	return m.k.WatchSecretData(ctx, string(secretName), NamespaceDefault, func(t kclient.SecretChangeType, secret *corev1.Secret) {
+	return m.k.WatchSecretData(ctx, string(secretName), AtlasNamespace, func(t kclient.SecretChangeType, secret *corev1.Secret) {
 		switch t {
 		case kclient.SecretChangeTypeAdd:
 			fallthrough
@@ -335,7 +335,7 @@ func (m *tlsManager) getTLSClientConf(clientName ClientName) (*tls.Config, error
 		return nil, err
 	}
 
-	secret := m.k.FetchSecretData(string(secretName), NamespaceDefault)
+	secret := m.k.FetchSecretData(string(secretName), AtlasNamespace)
 	if secret == nil || len(secret.Data) == 0 {
 		return &tls.Config{InsecureSkipVerify: true}, nil
 	}
@@ -365,7 +365,7 @@ func (m *tlsManager) getTLSConfFromSecrets(serverName ClientName) (*tls.Config, 
 	if err != nil {
 		return nil, err
 	}
-	secret := m.k.FetchSecretData(string(secretName), NamespaceDefault)
+	secret := m.k.FetchSecretData(string(secretName), AtlasNamespace)
 	if secret == nil || len(secret.Data) == 0 {
 		return nil, nil
 	}

--- a/workflowtrigger/api/argo/argo_authenticator_api.go
+++ b/workflowtrigger/api/argo/argo_authenticator_api.go
@@ -120,5 +120,10 @@ func (a *ArgoApiImpl) CheckApiKey(r *http.Request) bool {
 	if apikeyStrings == nil || len(apikeyStrings) < 1 {
 		return false
 	}
-	return a.apikeysManager.VerifyRequest(apikeyStrings[0])
+	verified, err := a.apikeysManager.VerifyRequest(apikeyStrings[0])
+	if err != nil {
+		log.Println("failed to verify request with apikey, error: ", err.Error())
+		return false
+	}
+	return verified
 }

--- a/workflowtrigger/api/argo/argo_authenticator_api.go
+++ b/workflowtrigger/api/argo/argo_authenticator_api.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 	"strings"
+
+	"greenops.io/workflowtrigger/apikeysmanager"
 
 	"github.com/argoproj/argo-cd/pkg/apiclient/account"
 	"google.golang.org/grpc/status"
@@ -27,12 +30,21 @@ const (
 	OverrideAction RbacAction = "override"
 )
 
+var AllowedApiKeysEndpointRegex = []string{
+	`\/client\/generateNotification\/.*$`,
+	`\/client\/.*\/.*\/generateEvent$`,
+}
+
 type ArgoAuthenticatorApi interface {
 	CheckRbacPermissions(action RbacAction, resource RbacResource, subresource string) bool
 }
 
 func (a *ArgoApiImpl) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if a.CheckApiKey(r) {
+			next.ServeHTTP(w, r)
+		}
+
 		token := r.Header.Get("Authorization")
 		splitToken := strings.Split(token, "Bearer ")
 		token = splitToken[1]
@@ -87,4 +99,26 @@ func (a *ArgoApiImpl) CheckRbacPermissions(action RbacAction, resource RbacResou
 		panic(fmt.Sprintf("Request to Argo server failed: %s", err))
 	}
 	return canI.Value == "yes"
+}
+
+func (a *ArgoApiImpl) CheckApiKey(r *http.Request) bool {
+	var pathAllowed bool
+	for _, regex := range AllowedApiKeysEndpointRegex {
+		matched, err := regexp.MatchString(regex, r.URL.Path)
+		if err != nil {
+			return false
+		}
+		if matched {
+			pathAllowed = true
+		}
+	}
+	if !pathAllowed {
+		return false
+	}
+
+	apikeyStrings := r.Header[apikeysmanager.ApiKeyHeaderName]
+	if apikeyStrings == nil || len(apikeyStrings) < 1 {
+		return false
+	}
+	return a.apikeysManager.VerifyRequest(apikeyStrings[0])
 }

--- a/workflowtrigger/api/argo/core_argo_client.go
+++ b/workflowtrigger/api/argo/core_argo_client.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"os"
 
+	"greenops.io/workflowtrigger/apikeysmanager"
+
 	"github.com/argoproj/argo-cd/pkg/apiclient"
 	grpcutil "github.com/argoproj/argo-cd/util/grpc"
 	"github.com/greenopsinc/util/config"
@@ -32,11 +34,12 @@ type ArgoApiImpl struct {
 	tlsCertPath      string
 	rawClient        apiclient.Client
 	configuredClient apiclient.Client
+	apikeysManager   apikeysmanager.Manager
 }
 
-func New(tm tlsmanager.Manager) ArgoApi {
+func New(tm tlsmanager.Manager, apikeysManager apikeysmanager.Manager) ArgoApi {
 	apiServerAddress := getClientCreationData()
-	argoApi := &ArgoApiImpl{apiServerAddress: apiServerAddress, tm: tm}
+	argoApi := &ArgoApiImpl{apiServerAddress: apiServerAddress, tm: tm, apikeysManager: apikeysManager}
 	argoApi.initArgoClient()
 	return argoApi
 }

--- a/workflowtrigger/api/commanddelegator/command_delegator_api.go
+++ b/workflowtrigger/api/commanddelegator/command_delegator_api.go
@@ -54,12 +54,8 @@ func (c *commandDelegatorApi) SendNotification(orgName string, clusterName strin
 		panic(err)
 	}
 
-	apikey, err := c.apiKeysManager.GetWorkflowTriggerApiKey()
-	if err != nil {
-		panic(err)
-	}
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set(apikeysmanager.ApiKeyHeaderName, apikey)
+	request.Header.Set(apikeysmanager.ApiKeyHeaderName, c.apiKeysManager.GetWorkflowTriggerApiKey())
 	resp, err := c.client.Do(request)
 	if err != nil {
 		panic(err)

--- a/workflowtrigger/apikeysmanager/apikeysmanager.go
+++ b/workflowtrigger/apikeysmanager/apikeysmanager.go
@@ -10,7 +10,7 @@ import (
 const (
 	workflowTriggerApiKeySecretName = "atlas-workflow-trigger-api-key"
 	clientWrapperApiKeySecretName   = "atlas-client-wrapper-api-key"
-	ApiKeyHeaderName                = "api-key"
+	ApiKeyHeaderName                = "X-Api-Key"
 )
 
 type Manager interface {
@@ -28,7 +28,9 @@ type manager struct {
 }
 
 func New(kubernetesClient kubernetesclient.KubernetesClient) Manager {
-	return &manager{client: apikeys.New(kubernetesClient)}
+	apikeysClient := apikeys.New(kubernetesClient)
+	apikeysClient.GetAll()
+	return &manager{client: apikeysClient}
 }
 
 func (m *manager) GenerateDefaultKeys() error {

--- a/workflowtrigger/apikeysmanager/apikeysmanager.go
+++ b/workflowtrigger/apikeysmanager/apikeysmanager.go
@@ -1,0 +1,85 @@
+package apikeysmanager
+
+import (
+	"fmt"
+
+	"github.com/greenopsinc/util/apikeys"
+	"github.com/greenopsinc/util/kubernetesclient"
+)
+
+const (
+	workflowTriggerApiKeySecretName = "atlas-workflow-trigger-api-key"
+	clientWrapperApiKeySecretName   = "atlas-client-wrapper-api-key"
+	ApiKeyHeaderName                = "api-key"
+)
+
+type Manager interface {
+	GenerateDefaultKeys() error
+	GenerateClientWrapperApiKey(name string) (string, error)
+	GetWorkflowTriggerApiKey() (string, error)
+	RotateWorkflowTriggerApiKey() (string, error)
+	RotateClientWrapperApiKey(name string) (string, error)
+	VerifyRequest(apikey string) bool
+}
+
+type manager struct {
+	client                apikeys.Client
+	workflowTriggerApiKey string
+}
+
+func New(kubernetesClient kubernetesclient.KubernetesClient) Manager {
+	return &manager{client: apikeys.New(kubernetesClient)}
+}
+
+func (m *manager) GenerateDefaultKeys() error {
+	_, err := m.client.Issue(workflowTriggerApiKeySecretName)
+	if err != nil {
+		return err
+	}
+	_, err = m.client.Issue(clientWrapperApiKeySecretName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *manager) GenerateClientWrapperApiKey(clusterName string) (string, error) {
+	secretName := fmt.Sprintf("atlas-%s-cluster-client-wrapper-api-key", clusterName)
+	return m.client.Issue(secretName)
+}
+
+func (m *manager) GetWorkflowTriggerApiKey() (string, error) {
+	apikey, err := m.client.Get(workflowTriggerApiKeySecretName)
+	if err != nil {
+		return "", err
+	}
+	if apikey != "" {
+		return apikey, nil
+	}
+	apikey, err = m.client.Issue(workflowTriggerApiKeySecretName)
+	if err != nil {
+		return "", err
+	}
+	return apikey, nil
+}
+
+func (m *manager) RotateWorkflowTriggerApiKey() (string, error) {
+	apikey, err := m.client.Rotate(workflowTriggerApiKeySecretName)
+	if err != nil {
+		return "", err
+	}
+	m.workflowTriggerApiKey = apikey
+	return apikey, nil
+}
+
+func (m *manager) RotateClientWrapperApiKey(clusterName string) (string, error) {
+	return m.client.Rotate(getClientWrapperApiKeyName(clusterName))
+}
+
+func getClientWrapperApiKeyName(clusterName string) string {
+	return fmt.Sprintf("atlas-%s-cluster-client-wrapper-api-key", clusterName)
+}
+
+func (m *manager) VerifyRequest(apikey string) bool {
+	return apikey == m.workflowTriggerApiKey
+}

--- a/workflowtrigger/main.go
+++ b/workflowtrigger/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"log"
 
-	"greenops.io/workflowtrigger/apikeysmanager"
-
 	"github.com/gorilla/mux"
 	"github.com/greenopsinc/util/db"
 	"github.com/greenopsinc/util/httpserver"
@@ -16,6 +14,7 @@ import (
 	"greenops.io/workflowtrigger/api/argo"
 	"greenops.io/workflowtrigger/api/commanddelegator"
 	"greenops.io/workflowtrigger/api/reposerver"
+	"greenops.io/workflowtrigger/apikeysmanager"
 	"greenops.io/workflowtrigger/schemavalidation"
 )
 

--- a/workflowtrigger/main.go
+++ b/workflowtrigger/main.go
@@ -35,16 +35,18 @@ func main() {
 	if err = apikeysManager.GenerateDefaultKeys(); err != nil {
 		log.Fatal(err)
 	}
+	if err = apikeysManager.WatchApiKeys(); err != nil {
+		log.Fatal(err)
+	}
 	commandDelegatorApi, err := commanddelegator.New(starter.GetCommandDelegatorServerClientConfig(), tlsManager, apikeysManager)
 	if err != nil {
 		log.Fatal(err)
 	}
-	argoAuthenticatorApi := argo.New(tlsManager).GetAuthenticatorApi()
+	argoAuthenticatorApi := argo.New(tlsManager, apikeysManager).GetAuthenticatorApi()
 	schemaValidator := schemavalidation.New(argoAuthenticatorApi, repoManagerApi)
 	r := mux.NewRouter()
-	api.InitClients(dbOperator, kafkaClient, kubernetesClient, repoManagerApi, argo.New(tlsManager).GetClusterApi(), commandDelegatorApi, schemaValidator)
+	api.InitClients(dbOperator, kafkaClient, kubernetesClient, repoManagerApi, argo.New(tlsManager, apikeysManager).GetClusterApi(), commandDelegatorApi, schemaValidator)
 	r.Use(argoAuthenticatorApi.(*argo.ArgoApiImpl).Middleware)
-	log.Println("setup middleware...")
 	api.InitializeLocalCluster()
 	api.InitPipelineTeamEndpoints(r)
 	api.InitStatusEndpoints(r)

--- a/workflowtrigger/main.go
+++ b/workflowtrigger/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/greenopsinc/util/apikeys"
+	"greenops.io/workflowtrigger/apikeysmanager"
 
 	"github.com/gorilla/mux"
 	"github.com/greenopsinc/util/db"
@@ -31,8 +31,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	apiKeysClient := apikeys.New(kubernetesClient)
-	commandDelegatorApi, err := commanddelegator.New(starter.GetCommandDelegatorServerClientConfig(), tlsManager, apiKeysClient)
+	apikeysManager := apikeysmanager.New(kubernetesClient)
+	if err = apikeysManager.GenerateDefaultKeys(); err != nil {
+		log.Fatal(err)
+	}
+	commandDelegatorApi, err := commanddelegator.New(starter.GetCommandDelegatorServerClientConfig(), tlsManager, apikeysManager)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,7 +48,7 @@ func main() {
 	api.InitializeLocalCluster()
 	api.InitPipelineTeamEndpoints(r)
 	api.InitStatusEndpoints(r)
-	api.InitClusterEndpoints(r)
+	api.InitClusterEndpoints(r, apikeysManager)
 
 	httpserver.CreateAndWatchServer(tlsmanager.ClientWorkflowTrigger, tlsManager, r)
 }


### PR DESCRIPTION
## Issue

Given that Client Wrappers are going to be deployed in different clusters and will be querying the Command Delegator/pushing messages to the Workflow Trigger, it is important to set up an authentication process. An API key would also be required by the Workflow Trigger, as it sends messages to the Command Delegator as well.

It was decided that assigning users to each ClientWrapper was too cumbersome. It makes the most sense to generate an API key when a user queries creates a new cluster. The API key should then be passed into the ClientWrapper for the cluster in question and used to make requests to the Workflow Trigger and Command Delegator.

There should also be an API key used for all instances of the Workflow Trigger (this should be out of the box, should not need to be configured). The in-cluster Client Wrapper should also have an API key that comes out of the box (this will require some discussion around implementation...).

The API key can simply be a verifiable random hash, it doesn't have to be a JWT as we do not need parameters like signage or token length. The token should never expire.

When a user desires, they can query for a new token (on a per cluster basis), which should retire the cluster's old access token and provide a new one. This will require an API method.

## Solution

- [x] Add apikeys client and manager packages
- [x] Add apikeys for client wrapper and workflow trigger
- [x] Add apikeys verification logic to workflow trigger and command delegator
- [x] Fix manifests for atlas in test_config