### PR TITLE
Simplify SSL configuration

### DIFF
--- a/util/build.gradle
+++ b/util/build.gradle
@@ -31,6 +31,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.apache.httpcomponents:httpclient:4.5'
     implementation 'org.springframework.kafka:spring-kafka:2.7.6'
-    implementation 'io.github.hakky54:sslcontext-kickstart-for-pem:7.2.1'
+    implementation 'io.github.hakky54:sslcontext-kickstart-for-pem:7.3.0'
 //    testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/util/src/main/java/com/greenops/util/httpclient/Builder.java
+++ b/util/src/main/java/com/greenops/util/httpclient/Builder.java
@@ -9,8 +9,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.springframework.stereotype.Component;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509ExtendedKeyManager;
-import javax.net.ssl.X509ExtendedTrustManager;
 import java.io.File;
 import java.nio.file.Paths;
 
@@ -40,8 +38,8 @@ public class Builder {
             return this;
         }
 
-        X509ExtendedKeyManager keyManager = PemUtils.loadIdentityMaterial(Paths.get(certPemPath), Paths.get(keyPemPath));
-        X509ExtendedTrustManager trustManager = PemUtils.loadTrustMaterial(Paths.get(certPemPath));
+        var keyManager = PemUtils.loadIdentityMaterial(Paths.get(certPemPath), Paths.get(keyPemPath));
+        var trustManager = PemUtils.loadTrustMaterial(Paths.get(certPemPath));
         var sslFactory = SSLFactory.builder()
                 .withIdentityMaterial(keyManager)
                 .withTrustMaterial(trustManager)
@@ -52,7 +50,7 @@ public class Builder {
 
     public HttpClient build() {
         if (this.sslCon == null) {
-            SSLFactory sslFactory = SSLFactory.builder()
+            var sslFactory = SSLFactory.builder()
                     .withUnsafeTrustMaterial()
                     .withUnsafeHostnameVerifier()
                     .build();


### PR DESCRIPTION
This PR resolves the following issue: https://github.com/GreenOpsInc/atlas/issues/60

The existing code uses a fallback mechanism to trust all certificates when the SSLContext is not initialised. A custom TrustManager with a SSLContext has been initialised, which is not needed as the utility class SSLFactory already has these options. So this PR is just to simplify the existing configuration. 